### PR TITLE
Need to define class function as static when it's being used as a static function

### DIFF
--- a/Source/ECPay-shipping-integration.php
+++ b/Source/ECPay-shipping-integration.php
@@ -1582,7 +1582,7 @@ class ECPayShippingOptions
     }
 
     // 取得正規表示式
-    function getRegex($field)
+    static function getRegex($field)
     {
         $pattern = '';
 


### PR DESCRIPTION
This is a small fix to prevent warning/errors for PHP7.x developers using this plugin.

Using PHP7.x you will get his warning message:
`Deprecated: Non-static method ECPayShippingOptions::getRegex() should not be called statically`

I'm not sure if it shows up for PHP5.x but it's still best practices to explicitly define functions as static if they're being used statically.

Please merge with main branch if this aligns with other files in the system.